### PR TITLE
Moved scores to keep consistency with playnite

### DIFF
--- a/source/Views/DetailsViewGameOverview.xaml
+++ b/source/Views/DetailsViewGameOverview.xaml
@@ -2024,6 +2024,10 @@
 																		<Setter Property="HorizontalAlignment" Value="{DynamicResource DetailGameDetailsValueHorizontalAlignment}" />
 																	</Style>
 																</Grid.Resources>
+																
+																<Label Name="PART_ElemUserScore" Content="{DynamicResource LOCUserScore}" />
+																<TextBlock Name="PART_TextUserScore" VerticalAlignment="Center" HorizontalAlignment="{DynamicResource DetailGameDetailsValueHorizontalAlignment}"
+																		Style="{DynamicResource TextBlockGameScore}" Margin="0,4,0,0" />
 
 																<Label Name="PART_ElemCommunityScore" Content="{DynamicResource LOCCommunityScore}" />
 																<TextBlock Name="PART_TextCommunityScore" VerticalAlignment="Center" HorizontalAlignment="{DynamicResource DetailGameDetailsValueHorizontalAlignment}"
@@ -2031,10 +2035,6 @@
 
 																<Label Name="PART_ElemCriticScore" Content="{DynamicResource LOCCriticScore}" />
 																<TextBlock Name="PART_TextCriticScore" VerticalAlignment="Center" HorizontalAlignment="{DynamicResource DetailGameDetailsValueHorizontalAlignment}"
-																		Style="{DynamicResource TextBlockGameScore}" Margin="0,4,0,0" />
-
-																<Label Name="PART_ElemUserScore" Content="{DynamicResource LOCUserScore}" />
-																<TextBlock Name="PART_TextUserScore" VerticalAlignment="Center" HorizontalAlignment="{DynamicResource DetailGameDetailsValueHorizontalAlignment}"
 																		Style="{DynamicResource TextBlockGameScore}" Margin="0,4,0,0" />
 																		
 																<Label Name="PART_ElemPlatform" Content="{DynamicResource LOCPlatformTitle}" />

--- a/source/Views/GridViewGameOverview.xaml
+++ b/source/Views/GridViewGameOverview.xaml
@@ -2068,6 +2068,10 @@
 																			</Style>
 																		</Grid.Resources>
 																		
+																		<Label Name="PART_ElemUserScore" Content="{DynamicResource LOCUserScore}" />
+																		<TextBlock Name="PART_TextUserScore" VerticalAlignment="Center" HorizontalAlignment="{DynamicResource GridGameDetailsValueHorizontalAlignment}"
+																				Style="{DynamicResource TextBlockGameScore}" Margin="0,4,0,0" />
+																		
 																		<Label Name="PART_ElemCommunityScore" Content="{DynamicResource LOCCommunityScore}" />
 																		<TextBlock Name="PART_TextCommunityScore" VerticalAlignment="Center" HorizontalAlignment="{DynamicResource GridGameDetailsValueHorizontalAlignment}"
 																				Style="{DynamicResource TextBlockGameScore}" Margin="0,4,0,0"/>
@@ -2075,10 +2079,6 @@
 																		<Label Name="PART_ElemCriticScore" Content="{DynamicResource LOCCriticScore}" />
 																		<TextBlock Name="PART_TextCriticScore" VerticalAlignment="Center" HorizontalAlignment="{DynamicResource GridGameDetailsValueHorizontalAlignment}"
 																				Style="{DynamicResource TextBlockGameScore}" Margin="0,4,0,0"/>
-
-																		<Label Name="PART_ElemUserScore" Content="{DynamicResource LOCUserScore}" />
-																		<TextBlock Name="PART_TextUserScore" VerticalAlignment="Center" HorizontalAlignment="{DynamicResource GridGameDetailsValueHorizontalAlignment}"
-																				Style="{DynamicResource TextBlockGameScore}" Margin="0,4,0,0" />
 
 																		<Label Name="PART_ElemPlatform" Content="{DynamicResource LOCPlatformTitle}" />
 																		<ItemsControl Name="PART_ItemsPlatforms" Margin="0,4,0,0" />


### PR DESCRIPTION
Hi, I moved the scores localization in the details pane in order to keep consistency with playnite itself, since currently the order was different between playnite and this theme. Feel free to reject this if you want to.

Playnite edition view: user - critics - community
![image](https://user-images.githubusercontent.com/11770760/171168139-d49913b7-51fb-41e6-9160-c6626a0ac052.png)

Theme before these changes: community - critics - user

Grid view:
![image](https://user-images.githubusercontent.com/11770760/171169286-efebc836-cc0a-4340-998f-4fd400f08cd2.png)

Details view:
![image](https://user-images.githubusercontent.com/11770760/171169350-4caece24-2933-4960-a6f1-44ce9d593896.png)

Theme after these changes: user - critics - community

Grid view:
![image](https://user-images.githubusercontent.com/11770760/171168697-990d2659-42c1-4efb-8da0-6feecd6c424e.png)

Details view:
![image](https://user-images.githubusercontent.com/11770760/171168804-dd5d9935-d2e2-4bfc-bec1-ecfc25e790e8.png)
